### PR TITLE
Queue by channel

### DIFF
--- a/Core/Inc/usbd_gs_can.h
+++ b/Core/Inc/usbd_gs_can.h
@@ -78,7 +78,7 @@ typedef struct {
 	USBD_SetupReqTypedef last_setup_request;
 	struct gs_host_frame_object from_host_frame;
 	CAN_HANDLE_TYPEDEF *channels[CAN_NUM_CHANNELS];
-#if (USE_MULTICHANNEL_QUEUE == 1)
+#if defined (USE_MULTICHANNEL_QUEUE)
 	QueueHandle_t queue_from_hostHandle[CAN_NUM_CHANNELS];
 #else
 	QueueHandle_t queue_from_hostHandle;

--- a/Core/Inc/usbd_gs_can.h
+++ b/Core/Inc/usbd_gs_can.h
@@ -78,7 +78,11 @@ typedef struct {
 	USBD_SetupReqTypedef last_setup_request;
 	struct gs_host_frame_object from_host_frame;
 	CAN_HANDLE_TYPEDEF *channels[CAN_NUM_CHANNELS];
+#if (USE_MULTICHANNEL_QUEUE == 1)
 	QueueHandle_t queue_from_hostHandle[CAN_NUM_CHANNELS];
+#else
+	QueueHandle_t queue_from_hostHandle;
+#endif
 	QueueHandle_t queue_to_hostHandle;
 	bool dfu_detach_requested;
 	bool pad_pkts_to_max_pkt_size;

--- a/Core/Inc/usbd_gs_can.h
+++ b/Core/Inc/usbd_gs_can.h
@@ -78,7 +78,7 @@ typedef struct {
 	USBD_SetupReqTypedef last_setup_request;
 	struct gs_host_frame_object from_host_frame;
 	CAN_HANDLE_TYPEDEF *channels[CAN_NUM_CHANNELS];
-	QueueHandle_t queue_from_hostHandle;
+	QueueHandle_t queue_from_hostHandle[CAN_NUM_CHANNELS];
 	QueueHandle_t queue_to_hostHandle;
 	bool dfu_detach_requested;
 	bool pad_pkts_to_max_pkt_size;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -251,7 +251,6 @@ void task_queue_from_host(void *argument)
 {
   UNUSED(argument);
   struct gs_host_frame_object frame_object;
-  bool new_frame;
 
   /* Infinite loop */
   for(;;)

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -69,6 +69,11 @@ static TaskHandle_t xCreatedMainTask;
 static TaskHandle_t xCreatedQtoHostTask;
 static TaskHandle_t xCreatedQfromHostTask;
 
+#if (USE_MULTICHANNEL_QUEUE == 1)
+static QueueSetHandle_t xFromHostQueueSet;
+static QueueSetMemberHandle_t xActivatedMember;
+#endif
+
 USBD_HandleTypeDef hUSB;
 USBD_GS_CAN_HandleTypeDef hGS_CAN;
 
@@ -141,9 +146,15 @@ int main(void)
               TASK_Q_FROM_HOST_STACK_PRIORITY, &xCreatedQfromHostTask);
 
   /* Init the RTOS streams and queues */
+#if (USE_MULTICHANNEL_QUEUE == 1)
+  xFromHostQueueSet = xQueueCreateSet(QUEUE_SIZE_DEV_TO_HOST * CAN_NUM_CHANNELS);
   for(uint8_t i=0; i<CAN_NUM_CHANNELS; i++) {
     hGS_CAN.queue_from_hostHandle[i] = xQueueCreate(QUEUE_SIZE_HOST_TO_DEV, GS_HOST_FRAME_SIZE);
+    xQueueAddToSet(hGS_CAN.queue_from_hostHandle[i], xFromHostQueueSet);
   }
+#else
+  hGS_CAN.queue_from_hostHandle = xQueueCreate(QUEUE_SIZE_HOST_TO_DEV, GS_HOST_FRAME_SIZE);
+#endif
   hGS_CAN.queue_to_hostHandle = xQueueCreate(QUEUE_SIZE_DEV_TO_HOST, GS_HOST_FRAME_SIZE);
 
   /* Start scheduler */
@@ -240,39 +251,39 @@ void task_queue_from_host(void *argument)
 {
   UNUSED(argument);
   struct gs_host_frame_object frame_object;
-  bool new_frame;
 
   /* Infinite loop */
   for(;;)
   {
-    new_frame = false;
-    /* Check the queue to see if we have data FROM the host to handle */
-    for(uint8_t i=0; i<CAN_NUM_CHANNELS; i++) {
-      if (xQueueReceive(hGS_CAN.queue_from_hostHandle[i], &frame_object.frame, 0) == pdPASS){
-        new_frame = true;
-      }
-    }
-    
-    if(new_frame) {
+#if (USE_MULTICHANNEL_QUEUE == 1)
+    /* wait for a queue member to become active */
+    xActivatedMember = xQueueSelectFromSet(xFromHostQueueSet, portMAX_DELAY);
+    xQueueReceive(xActivatedMember, &frame_object.frame, 0); 
+#else
+    xQueueReceive(hGS_CAN.queue_from_hostHandle, &frame_object.frame, portMAX_DELAY);
+#endif
+
 #if defined(LIN_FEATURE_ENABLED)
-      if (IS_LIN_FRAME(frame_object.frame.can_id)) {
-        lin_process_frame(&frame_object.frame);
-        continue; /* just loop again so this frame isn't sent on CAN bus */
-      }
-#endif /* LIN_FEATURE_ENABLED */
-      if (can_send(hGS_CAN.channels[frame_object.frame.channel], &frame_object.frame)) {
-        /* Echo sent frame back to host */
-        frame_object.frame.reserved = 0x0;
-        xQueueSendToBack(hGS_CAN.queue_to_hostHandle, &frame_object.frame, 0);
-        can_on_tx_cb(frame_object.frame.channel, &frame_object.frame);
-      }
-      else {
-          xQueueSendToFront(hGS_CAN.queue_from_hostHandle[frame_object.frame.channel], &frame_object.frame, 0);
-      } 
+    if (IS_LIN_FRAME(frame_object.frame.can_id)) {
+      lin_process_frame(&frame_object.frame);
+      continue; /* just loop again so this frame isn't sent on CAN bus */
     }
-    vTaskDelay(pdMS_TO_TICKS(0));
+#endif /* LIN_FEATURE_ENABLED */
+    if (can_send(hGS_CAN.channels[frame_object.frame.channel], &frame_object.frame)) {
+      /* Echo sent frame back to host */
+      frame_object.frame.reserved = 0x0;
+      xQueueSendToBack(hGS_CAN.queue_to_hostHandle, &frame_object.frame, 0);
+      can_on_tx_cb(frame_object.frame.channel, &frame_object.frame);
+    }
+    else {
+#if (USE_MULTICHANNEL_QUEUE == 1)
+        xQueueSendToFront(hGS_CAN.queue_from_hostHandle[frame_object.frame.channel], &frame_object.frame, 0);
+#else
+        xQueueSendToFront(hGS_CAN.queue_from_hostHandle, &frame_object.frame, 0);
+#endif
+    } 
   }
-    
+  vTaskDelay(pdMS_TO_TICKS(0));  
 }
 
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -69,7 +69,7 @@ static TaskHandle_t xCreatedMainTask;
 static TaskHandle_t xCreatedQtoHostTask;
 static TaskHandle_t xCreatedQfromHostTask;
 
-#if (USE_MULTICHANNEL_QUEUE == 1)
+#if defined (USE_MULTICHANNEL_QUEUE)
 static QueueSetHandle_t xFromHostQueueSet;
 static QueueSetMemberHandle_t xActivatedMember;
 #endif
@@ -146,7 +146,7 @@ int main(void)
               TASK_Q_FROM_HOST_STACK_PRIORITY, &xCreatedQfromHostTask);
 
   /* Init the RTOS streams and queues */
-#if (USE_MULTICHANNEL_QUEUE == 1)
+#if defined (USE_MULTICHANNEL_QUEUE)
   xFromHostQueueSet = xQueueCreateSet(QUEUE_SIZE_DEV_TO_HOST * CAN_NUM_CHANNELS);
   for(uint8_t i=0; i<CAN_NUM_CHANNELS; i++) {
     hGS_CAN.queue_from_hostHandle[i] = xQueueCreate(QUEUE_SIZE_HOST_TO_DEV, GS_HOST_FRAME_SIZE);
@@ -255,7 +255,7 @@ void task_queue_from_host(void *argument)
   /* Infinite loop */
   for(;;)
   {
-#if (USE_MULTICHANNEL_QUEUE == 1)
+#if defined (USE_MULTICHANNEL_QUEUE)
     /* wait for a queue member to become active */
     xActivatedMember = xQueueSelectFromSet(xFromHostQueueSet, portMAX_DELAY);
     xQueueReceive(xActivatedMember, &frame_object.frame, 0); 
@@ -276,7 +276,7 @@ void task_queue_from_host(void *argument)
       can_on_tx_cb(frame_object.frame.channel, &frame_object.frame);
     }
     else {
-#if (USE_MULTICHANNEL_QUEUE == 1)
+#if defined (USE_MULTICHANNEL_QUEUE)
         xQueueSendToFront(hGS_CAN.queue_from_hostHandle[frame_object.frame.channel], &frame_object.frame, 0);
 #else
         xQueueSendToFront(hGS_CAN.queue_from_hostHandle, &frame_object.frame, 0);

--- a/Core/Src/usbd_gs_can.c
+++ b/Core/Src/usbd_gs_can.c
@@ -539,10 +539,11 @@ static uint8_t USBD_GS_CAN_DataOut(USBD_HandleTypeDef *pdev, uint8_t epnum) {
 
 	uint32_t rxlen = USBD_LL_GetRxDataSize(pdev, epnum);
 #if defined(CANFD_FEATURE_ENABLED)
-	if (rxlen < (GS_HOST_CLASSIC_FRAME_SIZE)-4) {
+	if (rxlen < (GS_HOST_CLASSIC_FRAME_SIZE)-4)
 #else
-	if (rxlen < (GS_HOST_FRAME_SIZE)-4) {
+	if (rxlen < (GS_HOST_FRAME_SIZE)-4)
 #endif
+	{
 		// Invalid frame length, just ignore it and receive into the same buffer
 		// again next time.
 		USBD_GS_CAN_PrepareReceive(pdev);
@@ -550,7 +551,7 @@ static uint8_t USBD_GS_CAN_DataOut(USBD_HandleTypeDef *pdev, uint8_t epnum) {
 	}
 
 	// Enqueue the frame we just received.
-	xQueueSendToBackFromISR(hGS_CAN.queue_from_hostHandle, &hcan->from_host_frame, NULL);
+	xQueueSendToBackFromISR(hGS_CAN.queue_from_hostHandle[hcan->from_host_frame.frame.channel], &hcan->from_host_frame, NULL);
 	USBD_GS_CAN_PrepareReceive(pdev);
 	return USBD_OK;
 }

--- a/Core/Src/usbd_gs_can.c
+++ b/Core/Src/usbd_gs_can.c
@@ -551,7 +551,11 @@ static uint8_t USBD_GS_CAN_DataOut(USBD_HandleTypeDef *pdev, uint8_t epnum) {
 	}
 
 	// Enqueue the frame we just received.
+#if (USE_MULTICHANNEL_QUEUE == 1)	
 	xQueueSendToBackFromISR(hGS_CAN.queue_from_hostHandle[hcan->from_host_frame.frame.channel], &hcan->from_host_frame, NULL);
+#else
+	xQueueSendToBackFromISR(hGS_CAN.queue_from_hostHandle, &hcan->from_host_frame, NULL);
+#endif
 	USBD_GS_CAN_PrepareReceive(pdev);
 	return USBD_OK;
 }

--- a/Core/Src/usbd_gs_can.c
+++ b/Core/Src/usbd_gs_can.c
@@ -551,7 +551,7 @@ static uint8_t USBD_GS_CAN_DataOut(USBD_HandleTypeDef *pdev, uint8_t epnum) {
 	}
 
 	// Enqueue the frame we just received.
-#if (USE_MULTICHANNEL_QUEUE == 1)	
+#if defined (USE_MULTICHANNEL_QUEUE)
 	xQueueSendToBackFromISR(hGS_CAN.queue_from_hostHandle[hcan->from_host_frame.frame.channel], &hcan->from_host_frame, NULL);
 #else
 	xQueueSendToBackFromISR(hGS_CAN.queue_from_hostHandle, &hcan->from_host_frame, NULL);


### PR DESCRIPTION
Add a optional feature to have multiple "from host" queues for each of the CAN channels.  This prevents faulty CAN channels from affecting the others.